### PR TITLE
added reservedip/list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Vultr::Plans.list_vdc2
 Vultr::Regions.list
 Vultr::Regions.availability(DCID: dc_id)
 
-Vultr::RevervedIP.attach({ip_address: ip_address, attach_SUBID: attach_sub_id})
-Vultr::RevervedIP.convert({SUBID: sub_id, ip_address: ip_address, label: label})
-Vultr::RevervedIP.create({DCID: dc_id, ip_type: ip_type, label: label})
-Vultr::RevervedIP.destroy(ip_address: ip_address)
-Vultr::RevervedIP.detach({ip_address: ip_address, detach_SUBID: detach_sub_id})
-Vultr::RevervedIP.list
+Vultr::ReservedIP.attach({ip_address: ip_address, attach_SUBID: attach_sub_id})
+Vultr::ReservedIP.convert({SUBID: sub_id, ip_address: ip_address, label: label})
+Vultr::ReservedIP.create({DCID: dc_id, ip_type: ip_type, label: label})
+Vultr::ReservedIP.destroy(ip_address: ip_address)
+Vultr::ReservedIP.detach({ip_address: ip_address, detach_SUBID: detach_sub_id})
+Vultr::ReservedIP.list
 
 Vultr::Server.app_change({SUBID: sub_id, APPID: app_id})
 Vultr::Server.app_change_list(SUBID: sub_id)

--- a/lib/vultr.rb
+++ b/lib/vultr.rb
@@ -51,12 +51,12 @@ module Vultr
           availability: [:get, '/v1/regions/availability?DCID=[DCID]'],
           list: [:get, '/v1/regions/list']
       },
-      RevervedIP: {
-          attach: [:post, '/v1/reservedip/list?api_key=[api_key]', ['ip_address', 'attach_SUBID']],
-          convert: [:post, '/v1/reservedip/list?api_key=[api_key]', ['SUBID', 'ip_address', 'label']],
-          create: [:post, '/v1/reservedip/list?api_key=[api_key]', ['DCID', 'ip_type', 'label']],
-          destroy: [:post, '/v1/reservedip/list?api_key=[api_key]', ['ip_address']],
-          detach: [:post, '/v1/reservedip/list?api_key=[api_key]', ['ip_address', 'detach_SUBID']],
+      ReservedIP: {
+          attach: [:post, '/v1/reservedip/attach?api_key=[api_key]', ['ip_address', 'attach_SUBID']],
+          convert: [:post, '/v1/reservedip/convert?api_key=[api_key]', ['SUBID', 'ip_address', 'label']],
+          create: [:post, '/v1/reservedip/create?api_key=[api_key]', ['DCID', 'ip_type', 'label']],
+          destroy: [:post, '/v1/reservedip/destroy?api_key=[api_key]', ['ip_address']],
+          detach: [:post, '/v1/reservedip/detach?api_key=[api_key]', ['ip_address', 'detach_SUBID']],
           list: [:get, '/v1/reservedip/list?api_key=[api_key]']
       },
       Server: {


### PR DESCRIPTION
The current Reserved IP API is broken. Currently vultr.rb calls `list` for all the existing functions. This patch calls the correct endpoints, adds list and fixes the spelling mistake (will break backwards compatibility, but it was broken anyway so I doubt anyone was using it).  